### PR TITLE
Handle nil opts in setup function

### DIFF
--- a/lua/blackjack/init.lua
+++ b/lua/blackjack/init.lua
@@ -3,6 +3,8 @@ local window = require("blackjack.window")
 local M = {}
 
 M.setup = function(opts)
+  opts = opts or {}
+
   if opts.card_style ~= nil then
     window.card_style = opts.card_style
   end


### PR DESCRIPTION
Hello, I just saw your plugin on that reddit post and decided to test it. It does look nice, but there is an issue that if the setup call is called without any arguments, it tries to access `opts.card_style`, which throws an error, since `opts` is nil.

Since this is very simple, I make a quick fix instead of just opening an issue. I hope that's ok!

Also, you can create a "default options" table in the future and merge with user passed data. The way I coded just handles a nil `opts`.  You can check for example this line in this plugin: https://github.com/j-hui/fidget.nvim/blob/main/lua/fidget.lua#L518

It uses this `vim.tbl_deep_extend` built in (in nvim) function to handle that merge table. I'm not experienced with it, but I think it is worth checking in the future if you need to expand your plugin with more options.

By the way, I think you plugin is super cool!